### PR TITLE
Improve flexibility around plugin installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM sonarqube:latest
 MAINTAINER Deven Phillips <deven.phillips@redhat.com>
 
-RUN curl -L -o extensions/plugins/sonar-ldap-plugin.jar https://sonarsource.bintray.com/Distribution/sonar-ldap-plugin/sonar-ldap-plugin-2.1.0.507.jar
-RUN curl -L -o extensions/plugins/sonar-github-plugin.jar https://sonarsource.bintray.com/Distribution/sonar-github-plugin/sonar-github-plugin-1.4.1.822.jar
-RUN curl -L -o extensions/plugins/sonar-findbugs-plugin.jar https://github.com/SonarQubeCommunity/sonar-findbugs/releases/download/3.4.4/sonar-findbugs-plugin-3.4.4.jar
-RUN curl -L -o extensions/plugins/sonar-pmd-plugin.jar https://github.com/SonarQubeCommunity/sonar-pmd/releases/download/2.6/sonar-pmd-plugin-2.6.jar
-RUN curl -L -o extensions/plugins/sonar-gitlab-plugin.jar https://github.com/gabrie-allaigre/sonar-gitlab-plugin/releases/download/2.0.1/sonar-gitlab-plugin-2.0.1.jar
-RUN curl -L -o extensions/plugins/sonar-buildbreaker-plugin.jar https://github.com/SonarQubeCommunity/sonar-build-breaker/releases/download/2.2/sonar-build-breaker-plugin-2.2.jar
 RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init
 RUN cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init
 RUN chown 65534:0 /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD run.sh /opt/sonarqube/bin/run.sh
+CMD /opt/sonarqube/bin/run.sh
+ENV PLUGIN_LIST="findbug pmd gitlab github ldap buildbreaker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init
 RUN chown 65534:0 /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh
-ENV PLUGIN_LIST="findbug pmd gitlab github ldap buildbreaker"
+ENV SONAR_PLUGIN_LIST="findbug pmd gitlab github ldap buildbreaker"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ plugins will only be automatically installed on the first run with a new volume.
 configurable. You can provide no environment variables for configuration and the container will run with the built-in
 H2 DB and local authentication, but you can pass in configuration properties as listed below to customize the runtime.
 
+## Plugin Installation
+When the container is run, the environment variable "SONAR_PLUGIN_LIST" should contain a space separated list of 
+plugins which should be installed on the container's first startup.
 
 ## Configuration
 Some configuration settings are well defined, but you can always pass additional configuration using the catchall

--- a/README.md
+++ b/README.md
@@ -3,4 +3,87 @@ This is a modified Docker image based on the public sonarqube:latest
 image, but it has been modified to allow permissions to be run in an
 OpenShift environment.
 
+## Overview
+This image repository builds on the public Docker image for SonarQube. It adds a capability to automatically install
+plugins the first time the container is run. It also supports persistent volumes for configuration and plugins. The
+plugins will only be automatically installed on the first run with a new volume. The container image is also 
+configurable. You can provide no environment variables for configuration and the container will run with the built-in
+H2 DB and local authentication, but you can pass in configuration properties as listed below to customize the runtime.
 
+
+## Configuration
+Some configuration settings are well defined, but you can always pass additional configuration using the catchall
+`SONARQUBE_WEB_JVM_OPTS`. Any Java properties placed in this environment variable will be passed to the SonarQube 
+application. The format of the Java properties is like `-Dsome.java.property=someValue`, so you can add an environment
+variable like `SONARQUBE_WEB_JVM_OPTS="-Dsonar.auth.google.allowUsersToSignUp=false -Dsonar.auth.google.enabled=true"`
+
+### Pre-defined Configuration Variables
+
+```yaml
+- Variable: SONARQUBE_WEB_JVM_OPTS
+  Description: Extra startup properties for SonarQube (in the form of "-Dsonar.someProperty=someValue")
+  Default Value:
+- Variable: SONARQUBE_JDBC_USERNAME
+  Description: Username used for SonarQube database authentication (leave blank to use ephemeral database)
+  Default Value:
+- Variable: SONARQUBE_JDBC_PASSWORD
+  Description: Password used for SonarQube database authentication (leave blank to use ephemeral database)
+  Default Value:
+- Variable: SONARQUBE_JDBC_URL
+  Description: Password used for SonarQube database authentication (leave blank to use ephemeral database)
+  Default Value:
+- Variable: SONARQUBE_LDAP_BINDDN
+  Description: Bind DN for LDAP authentication (leave blank for local authentication)
+  Default Value:
+- Variable: SONARQUBE_LDAP_BINDPASSWD
+  Description: Bind password for LDAP authentication (leave blank for local authentication)
+  Default Value:
+- Variable: SONARQUBE_LDAP_URL
+  Description: LDAP URL for authentication (leave blank for local authentication)
+  Default Value:
+- Variable: SONARQUBE_LDAP_REALM
+  Description: LDAP Realm
+  Default Value:
+- Variable: SONARQUBE_LDAP_CONTEXTFACTORY
+  Description: JNDI ContextFactory class to be used
+  Default Value: com.sun.jndi.ldap.LdapCtxFactory
+- Variable: SONARQUBE_LDAP_STARTTLS
+  Description: Enable StartTLS for the LDAP connection
+  Default Value: "false"
+- Variable: SONARQUBE_LDAP_AUTHENTICATION
+  Description:  LDAP authentication method (simple | CRAM-MD5 | DIGEST-MD5 | GSSAPI)
+  Default Value: simple
+- Variable: SONARQUBE_LDAP_USER_BASEDN
+  Description: LDAP BaseDN under which to search for user objects
+  Default Value:
+- Variable: SONARQUBE_LDAP_USER_REQUEST
+  Description: LDAP filter to select user objects
+  Default Value: (&(objectClass=inetOrgPerson)(uid={login}))
+- Variable: SONARQUBE_LDAP_USER_REAL_NAME_ATTR
+  Description: LDAP attribute which holds the user's full name
+  Default Value: cn
+- Variable: SONARQUBE_LDAP_USER_EMAIL_ATTR
+  Description: LDAP attribute which holds the user's e-mail address
+  Default Value: mail
+- Variable: SONARQUBE_LDAP_GROUP_BASEDN
+  Description: LDAP BaseDN under which to search for group objects
+  Default Value:
+- Variable: SONARQUBE_LDAP_GROUP_REQUEST
+  Description: LDAP filter to select group objects
+  Default Value: (&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))
+- Variable: SONARQUBE_LDAP_GROUP_ID_ATTR
+  Description: LDAP attribute which holds the group's ID
+  Default Value: cn
+- Variable: SONARQUBE_BUILDBREAKER_MAX_ATTEMPTS
+  Description: Build Break plugin - Max number of poll attempts
+  Default Value: "30"
+- Variable: SONARQUBE_BUILDBREAKER_INTERVAL
+  Description: Build Breaker plugin - Interval to wait between poll requests
+  Default Value: "20000"
+- Variable: SONARQUBE_BUILDBREAKER_THRESHOLD
+  Description: Build Breaker plugin - Threshold at which a build will instantly break
+  Default Value: "CRITICAL"
+- Variable: SONAR_BUILDBREAKER_DISABLE
+  Description: Build Breaker plugin - Disable the build breaker plugin for all builds
+  Default Value: "true"
+```

--- a/run.sh
+++ b/run.sh
@@ -3,13 +3,23 @@
 set -e
 
 ## If the mounted data volume is empty, populate it from the default data
+## The plugins.txt file lists plugins which should be installed.
 if ! [[ "$(ls -A /opt/sonarqube/data)" ]]; then
-	cp -a /opt/sonarqube/data-init /opt/sonarqube/data
+    cp -a /opt/sonarqube/data-init /opt/sonarqube/data
 fi
 
 ## If the mounted extensions volume is empty, populate it from the default data
 if ! [[ -d /opt/sonarqube/data/plugins ]]; then
 	cp -a /opt/sonarqube/extensions-init/plugins /opt/sonarqube/data/plugins
+	curl -s https://update.sonarsource.org/update-center.properties | grep downloadUrl > /tmp/pluginList.txt
+	printf "Downloading additional plugins\n"
+    for PLUGIN in $(echo $PLUGIN_LIST)
+    do
+        printf "\t${PLUGIN}..."
+        DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${PLUGIN} | sort -V | tail -n 1 | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
+        curl -Ls -o /opt/sonarqube/data/plugins/${PLUGIN}.jar ${DOWNLOAD_URL}
+        printf "\n"
+    done
 fi
 
 rm -rf /opt/sonarqube/extensions/plugins
@@ -19,7 +29,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-chgrp -R 0 /opt/sonarqube && chmod -R g+rwX /opt/sonarqube
+chown -R 0:65534 /opt/sonarqube && chmod -R g+rwX /opt/sonarqube
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ if ! [[ -d /opt/sonarqube/data/plugins ]]; then
 	cp -a /opt/sonarqube/extensions-init/plugins /opt/sonarqube/data/plugins
 	curl -s https://update.sonarsource.org/update-center.properties | grep downloadUrl > /tmp/pluginList.txt
 	printf "Downloading additional plugins\n"
-    for PLUGIN in $(echo $PLUGIN_LIST)
+    for PLUGIN in $(echo $SONAR_PLUGIN_LIST)
     do
         printf "\t${PLUGIN}..."
         DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${PLUGIN} | sort -V | tail -n 1 | awk -F"=" '{print $2}' | sed 's@\\:@:@g')

--- a/run.sh
+++ b/run.sh
@@ -15,10 +15,17 @@ if ! [[ -d /opt/sonarqube/data/plugins ]]; then
 	printf "Downloading additional plugins\n"
     for PLUGIN in $(echo $SONAR_PLUGIN_LIST)
     do
-        printf "\t${PLUGIN}..."
         DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${PLUGIN} | sort -V | tail -n 1 | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
-        curl -Ls -o /opt/sonarqube/data/plugins/${PLUGIN}.jar ${DOWNLOAD_URL}
-        printf "\n"
+
+        ## Check to see if plugin exists, attempt to download the plugin if it does exist.
+        if ! [[ -z "${DOWNLOAD_URL}" ]]; then
+            printf "    %-15s" ${PLUGIN}
+            curl -Ls -o /opt/sonarqube/data/plugins/${PLUGIN}.jar ${DOWNLOAD_URL} >> /dev/null 2>&1 && printf "%10s" "DONE" || printf "%10s" "FAILED"
+            printf "\n"
+        else
+            ## Plugin was not found in the plugin inventory
+            printf "    %-15s%10s\n" "${PLUGIN}" "NOT FOUND"
+        fi
     done
 fi
 

--- a/sonarqube-template.yaml
+++ b/sonarqube-template.yaml
@@ -174,6 +174,8 @@ objects:
       spec:
         containers:
         - env:
+          - name: SONAR_PLUGIN_LIST
+            value: ${SONAR_PLUGIN_LIST}
           - name: SONARQUBE_WEB_JVM_OPTS
             value: ${SONARQUBE_WEB_JVM_OPTS}
           - name: SONARQUBE_JDBC_USERNAME
@@ -271,7 +273,7 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 parameters:
-- name: SONAR_PLUGINS
+- name: SONAR_PLUGIN_LIST
   description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
   value: findbugs pmd ldap buildbreaker github gitlab
 - name: VOLUME_CAPACITY

--- a/sonarqube-template.yaml
+++ b/sonarqube-template.yaml
@@ -5,6 +5,16 @@ metadata:
   name: sonarqube
 objects:
 - apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: sonar-config
+  spec:
+    accessModes:
+      - ReadWriteMany
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
   kind: Route
   metadata:
     annotations:
@@ -261,9 +271,12 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 parameters:
-- name: DEFAULT_DOMAIN
-  description: The name assigned to all objects and the resulting imagestream
-  value: 
+- name: SONAR_PLUGINS
+  description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
+  value: findbugs pmd ldap buildbreaker github gitlab
+- name: VOLUME_CAPACITY
+  description: The size of the Persistent Volume Claim to provision for SonarQube
+  value: 10Gi
 - name: SONARQUBE_WEB_JVM_OPTS
   description: Extra startup properties for SonarQube (in the form of "-Dsonar.someProperty=someValue")
   value:


### PR DESCRIPTION
This branch improves the `run.sh` script to enable installing arbitrary plugins on the first launch of the container. The env variable `SONAR_PLUGIN_LIST` provides a space separated list of plugins to be installed. If a plugin in the list does not exist, the `run.sh` script will log the failure but continue on.