### PR TITLE
Build with plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM sonarqube:latest
 MAINTAINER Deven Phillips <deven.phillips@redhat.com>
 
-ARG SONAR_PLUGINS_LIST=local
-ENV SONAR_PLUGINS_LIST ${SONAR_PLUGINS_LIST}
 RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init
 RUN cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init
 RUN chown 65534:0 /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD plugins.sh /opt/sonarqube/bin/plugins.sh
-RUN /opt/sonarqube/bin/plugins.sh ${SONAR_PLUGINS_LIST}
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh
+ARG SONAR_PLUGINS_LIST=local
+ENV SONAR_PLUGINS_LIST ${SONAR_PLUGINS_LIST}
+RUN /opt/sonarqube/bin/plugins.sh ${SONAR_PLUGINS_LIST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM sonarqube:latest
 MAINTAINER Deven Phillips <deven.phillips@redhat.com>
 
+ARG SONAR_PLUGINS_LIST=local
+ENV SONAR_PLUGINS_LIST ${SONAR_PLUGINS_LIST}
 RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init
 RUN cp -a /opt/sonarqube/extensions /opt/sonarqube/extensions-init
 RUN chown 65534:0 /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
+ADD plugins.sh /opt/sonarqube/bin/plugins.sh
+RUN /opt/sonarqube/bin/plugins.sh ${SONAR_PLUGINS_LIST}
 ADD run.sh /opt/sonarqube/bin/run.sh
 CMD /opt/sonarqube/bin/run.sh
-ENV SONAR_PLUGIN_LIST="findbug pmd gitlab github ldap buildbreaker"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ variable like `SONARQUBE_WEB_JVM_OPTS="-Dsonar.auth.google.allowUsersToSignUp=fa
 
 ### Pre-defined Configuration Variables
 
-* Variable: **SONAR_PLUGIN_LIST**
+* Variable: **SONAR_PLUGINS_LIST**
   * Description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
   * Default Value: findbugs pmd ldap buildbreaker github gitlab
 * Variable: **SONARQUBE_WEB_JVM_OPTS**

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ configurable. You can provide no environment variables for configuration and the
 H2 DB and local authentication, but you can pass in configuration properties as listed below to customize the runtime.
 
 ## Plugin Installation
-When the container is run, the environment variable "SONAR_PLUGIN_LIST" should contain a space separated list of 
-plugins which should be installed on the container's first startup.
+When the container image is built, the environment variable "SONAR_PLUGINS_LIST" should contain a space separated list 
+of plugins which should be installed. More plugins can always be installed later as well.
 
 ## Configuration
 Some configuration settings are well defined, but you can always pass additional configuration using the catchall

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ variable like `SONARQUBE_WEB_JVM_OPTS="-Dsonar.auth.google.allowUsersToSignUp=fa
 
 ### Pre-defined Configuration Variables
 
+* Variable: **SONAR_PLUGIN_LIST**
+  * Description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
+  * Default Value: findbugs pmd ldap buildbreaker github gitlab
 * Variable: **SONARQUBE_WEB_JVM_OPTS**
   * Description: Extra startup properties for SonarQube (in the form of "-Dsonar.someProperty=someValue")
   * Default Value:

--- a/plugins.sh
+++ b/plugins.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+curl -s https://update.sonarsource.org/update-center.properties | grep downloadUrl > /tmp/pluginList.txt
+printf "Downloading additional plugins\n"
+for PLUGIN in "$@"
+do
+    DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${PLUGIN} | sort -V | tail -n 1 | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
+
+    ## Check to see if plugin exists, attempt to download the plugin if it does exist.
+    if ! [[ -z "${DOWNLOAD_URL}" ]]; then
+        printf "    %-15s" ${PLUGIN}
+        curl -Ls -o /opt/sonarqube/extensions-init/plugins/${PLUGIN}.jar ${DOWNLOAD_URL} >> /dev/null 2>&1 && printf "%10s" "DONE" || printf "%10s" "FAILED"
+        printf "\n"
+    else
+        ## Plugin was not found in the plugin inventory
+        printf "    %-15s%10s\n" "${PLUGIN}" "NOT FOUND"
+    fi
+done

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,6 @@
 set -e
 
 ## If the mounted data volume is empty, populate it from the default data
-## The plugins.txt file lists plugins which should be installed.
 if ! [[ "$(ls -A /opt/sonarqube/data)" ]]; then
     cp -a /opt/sonarqube/data-init /opt/sonarqube/data
 fi
@@ -11,24 +10,9 @@ fi
 ## If the mounted extensions volume is empty, populate it from the default data
 if ! [[ -d /opt/sonarqube/data/plugins ]]; then
 	cp -a /opt/sonarqube/extensions-init/plugins /opt/sonarqube/data/plugins
-	curl -s https://update.sonarsource.org/update-center.properties | grep downloadUrl > /tmp/pluginList.txt
-	printf "Downloading additional plugins\n"
-    for PLUGIN in $(echo $SONAR_PLUGIN_LIST)
-    do
-        DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${PLUGIN} | sort -V | tail -n 1 | awk -F"=" '{print $2}' | sed 's@\\:@:@g')
-
-        ## Check to see if plugin exists, attempt to download the plugin if it does exist.
-        if ! [[ -z "${DOWNLOAD_URL}" ]]; then
-            printf "    %-15s" ${PLUGIN}
-            curl -Ls -o /opt/sonarqube/data/plugins/${PLUGIN}.jar ${DOWNLOAD_URL} >> /dev/null 2>&1 && printf "%10s" "DONE" || printf "%10s" "FAILED"
-            printf "\n"
-        else
-            ## Plugin was not found in the plugin inventory
-            printf "    %-15s%10s\n" "${PLUGIN}" "NOT FOUND"
-        fi
-    done
 fi
 
+## Link the plugins directory from the mounted volume
 rm -rf /opt/sonarqube/extensions/plugins
 ln -s /opt/sonarqube/data/plugins /opt/sonarqube/extensions/plugins
 

--- a/sonarqube-template.yaml
+++ b/sonarqube-template.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: sonar-config
+    name: openshift-sonarqube
   spec:
     accessModes:
       - ReadWriteMany
@@ -124,6 +124,7 @@ objects:
     source:
       git:
         uri: https://github.com/InfoSec812/openshift-sonarqube.git
+        ref: build-with-plugins
       type: Git
     strategy:
       dockerStrategy:
@@ -131,8 +132,8 @@ objects:
           kind: ImageStreamTag
           name: sonarqube:latest
         env:
-          name: SONAR_PLUGINS_LIST
-          value: ${SONAR_PLUGINS_LIST}
+          - name: SONAR_PLUGINS_LIST
+            value: ${SONAR_PLUGINS_LIST}
       type: Docker
     triggers:
     - github:
@@ -248,15 +249,15 @@ objects:
           terminationMessagePath: /dev/termination-log
           volumeMounts:
           - mountPath: /opt/sonarqube/data
-            name: sonar-config
+            name: openshift-sonarqube
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
         terminationGracePeriodSeconds: 30
         volumes:
-        - name: sonar-config
+        - name: openshift-sonarqube
           persistentVolumeClaim:
-            claimName: sonar-config
+            claimName: openshift-sonarqube
     test: false
     triggers:
     - type: ConfigChange
@@ -277,7 +278,7 @@ objects:
     updatedReplicas: 0
 parameters:
 - name: SONAR_PLUGINS_LIST
-  description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
+  description: Space separated list of plugins
   value: findbugs pmd ldap buildbreaker github gitlab
 - name: VOLUME_CAPACITY
   description: The size of the Persistent Volume Claim to provision for SonarQube

--- a/sonarqube-template.yaml
+++ b/sonarqube-template.yaml
@@ -131,7 +131,8 @@ objects:
           kind: ImageStreamTag
           name: sonarqube:latest
         env:
-
+          name: SONAR_PLUGINS_LIST
+          value: ${SONAR_PLUGINS_LIST}
       type: Docker
     triggers:
     - github:
@@ -275,7 +276,7 @@ objects:
     unavailableReplicas: 0
     updatedReplicas: 0
 parameters:
-- name: SONAR_PLUGIN_LIST
+- name: SONAR_PLUGINS_LIST
   description: A space separated list of plugins to be installed (See: https://goo.gl/I9E4hL)
   value: findbugs pmd ldap buildbreaker github gitlab
 - name: VOLUME_CAPACITY

--- a/sonarqube-template.yaml
+++ b/sonarqube-template.yaml
@@ -130,6 +130,8 @@ objects:
         from:
           kind: ImageStreamTag
           name: sonarqube:latest
+        env:
+
       type: Docker
     triggers:
     - github:


### PR DESCRIPTION
Move the plugin installation logic to the Dockerfile build and make the build parameterized. Change the BuildConfig to pass in environment information into the Docker build so that the plugin list can be customized by the template.